### PR TITLE
GraphRelationBuilder - make property metadata type checking more robust

### DIFF
--- a/src/GraphRelationBuilder.ts
+++ b/src/GraphRelationBuilder.ts
@@ -73,12 +73,12 @@ export class GraphRelationBuilder {
           this.getEntityMetadata(currentTargetEntity).findEmbeddedWithPropertyPath(propPath);
 
         if (propMetadata != null) {
-          if (propMetadata instanceof RelationMetadata) {
+          if ('inverseEntityMetadata' in propMetadata) {
             currentTargetEntity = propMetadata.inverseEntityMetadata.target;
             nextLevel = currentLevel + 1;
             currentPropertyPath.push(propMetadata.propertyName);
             relationMap.add(currentPropertyPath);
-          } else if (propMetadata instanceof EmbeddedMetadata) {
+          } else if ('propertyPath' in propMetadata) {
             currentPropertyPath.push(propMetadata.propertyPath);
           }
         }


### PR DESCRIPTION
The property metadata is not properly identified to be an `instanceOf` `RelationMetadata` and `EmbeddedMetadata`, respectively, when run in Vite development mode in browser, possibly due to vitejs/vite#9528 .

This PR proposes the use of property checks instead to determine the type of the property's metadata.

This bug should probably be solved on Vite's side, since it seems to be isolated to their tooling, however the nuisance of using this not so clean workaround could be outweighed by the benefit of using a pretty popular frontend build tool, until that issue is resolved of course.
