### PR TITLE
Return an empty RelationMap from buildForQuery if path not found

### DIFF
--- a/src/GraphRelationBuilder.spec.ts
+++ b/src/GraphRelationBuilder.spec.ts
@@ -248,6 +248,39 @@ describe('GraphRelationBuilder', () => {
       ]);
     });
 
+    it('handles mapping a field path which is not present in GQL selection set', async () => {
+      // language=GraphQL
+      const query = `
+        query products {
+          products {
+            id
+            name
+          }
+        }
+      `;
+
+      const resolveInfoHook = (info: GraphQLResolveInfo): void => {
+        const relationMap = new GraphRelationBuilder(dataSource).buildForQuery(Store, info, 'store');
+
+        expect(relationMap.toFindOptionsRelations()).toEqual({});
+      };
+      const result = await graphql(executableSchema, query, {}, { resolveInfoHook });
+
+      // check we hit our assertions inside the resolveInfoHook callback
+      expect.assertions(1 + 4);
+
+      // check the query result looks right
+      expect(result).toBeDefined();
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toBeDefined();
+      expect(result.data?.products).toEqual([
+        {
+          id: expect.any(Number),
+          name: mockData.productA.name,
+        },
+      ]);
+    });
+
     it('maps GQL selections containing spread fragments to ORM relations', async () => {
       // language=GraphQL
       const query = `

--- a/src/GraphRelationBuilder.ts
+++ b/src/GraphRelationBuilder.ts
@@ -25,7 +25,7 @@ export class GraphRelationBuilder {
     const baseNode = path != null ? findSelectionNode(path, info) : rootNode;
 
     if (baseNode == null) {
-      throw new Error(`Could not locate field named "${path}" in query info"`);
+      return new RelationMap<Entity>();
     }
 
     return this.build(entity, baseNode, info.fragments);


### PR DESCRIPTION
When calling `buildForQuery` with a `path` argument, if that path is not found in the selection set then no relations need to be mapped. This should not throw an exception.